### PR TITLE
KO generate cyclonedx sbom

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,6 +65,10 @@ jobs:
 
   image:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     steps:
       - name: Clone repo
         uses: actions/checkout@v4
@@ -92,6 +96,11 @@ jobs:
         with:
           version: v0.14.1
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3.2.0
+        with:
+          cosign-release: "v2.2.1"
+
       - name: Prepare
         run: |
           echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
@@ -105,7 +114,7 @@ jobs:
           for i in "${arr[@]}"
           do
             export KO_DOCKER_REPO=${i}/${{ env.GHCR_REPO }}/grafana-operator
-            ko build --sbom=cyclonedx --bare --platform linux/arm64,linux/arm/v7,linux/amd64 -t ${{ github.ref_name }} \
+            ko build --sbom=cyclonedx --image-refs ./image-digest --bare --platform linux/arm64,linux/arm/v7,linux/amd64 -t ${{ github.ref_name }} \
             --image-label org.opencontainers.image.title=grafana-operator \
             --image-label org.opencontainers.image.description="An operator for Grafana that installs and manages Grafana instances & Dashboards & Datasources through Kubernetes/OpenShift CRs" \
             --image-label org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }} \
@@ -113,3 +122,6 @@ jobs:
             --image-label org.opencontainers.image.version=${{ github.ref_name }} \
             --image-label org.opencontainers.image.created=${{ env.BUILD_DATE }}
           done
+      - name: Sign Image
+        run: |
+          cosign sign -y $(cat ./image-digest)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -124,4 +124,4 @@ jobs:
           done
       - name: Sign Image
         run: |
-          cosign sign -y $(cat ./image-digest)
+          cosign sign -d -y $(cat ./image-digest)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -99,11 +99,11 @@ jobs:
       - name: Build and push
         run: |
           declare -a arr=("quay.io" "ghcr.io" )
-          
+
           for i in "${arr[@]}"
           do
             export KO_DOCKER_REPO=${i}/grafana-operator/grafana-operator
-            ko build --sbom=none --bare --platform linux/arm64,linux/arm/v7,linux/amd64 -t ${{ github.ref_name }} \
+            ko build --sbom=cyclonedx --bare --platform linux/arm64,linux/arm/v7,linux/amd64 -t ${{ github.ref_name }} \
             --image-label org.opencontainers.image.title=grafana-operator \
             --image-label org.opencontainers.image.description="An operator for Grafana that installs and manages Grafana instances & Dashboards & Datasources through Kubernetes/OpenShift CRs" \
             --image-label org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }} \
@@ -111,4 +111,3 @@ jobs:
             --image-label org.opencontainers.image.version=${{ github.ref_name }} \
             --image-label org.opencontainers.image.created=${{ env.BUILD_DATE }}
           done
-                 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -102,7 +102,7 @@ jobs:
 
           for i in "${arr[@]}"
           do
-            export KO_DOCKER_REPO=${i}/grafana-operator/grafana-operator
+            export KO_DOCKER_REPO=${i}//${{ github.repository_owner }}/grafana-operator
             ko build --sbom=cyclonedx --bare --platform linux/arm64,linux/arm/v7,linux/amd64 -t ${{ github.ref_name }} \
             --image-label org.opencontainers.image.title=grafana-operator \
             --image-label org.opencontainers.image.description="An operator for Grafana that installs and manages Grafana instances & Dashboards & Datasources through Kubernetes/OpenShift CRs" \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,12 +76,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login to Quay.io
-        uses: docker/login-action@v3
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
+      # - name: Login to Quay.io
+      #   uses: docker/login-action@v3
+      #   with:
+      #     registry: quay.io
+      #     username: ${{ secrets.QUAY_USERNAME }}
+      #     password: ${{ secrets.QUAY_PASSWORD }}
 
       - uses: actions/setup-go@v4
         with:
@@ -98,7 +98,7 @@ jobs:
 
       - name: Build and push
         run: |
-          declare -a arr=("quay.io" "ghcr.io" )
+          declare -a arr=("ghcr.io" )
 
           for i in "${arr[@]}"
           do

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,6 +95,8 @@ jobs:
       - name: Prepare
         run: |
           echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
+          GHCR_REPO=$(echo "ghcr.io/${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          echo "GHCR_REPO=$GHCR_REPO" >> $GITHUB_ENV
 
       - name: Build and push
         run: |
@@ -102,7 +104,7 @@ jobs:
 
           for i in "${arr[@]}"
           do
-            export KO_DOCKER_REPO=${i}//${{ github.repository_owner }}/grafana-operator
+            export KO_DOCKER_REPO=${i}/${{ env.GHCR_REPO }}/grafana-operator
             ko build --sbom=cyclonedx --bare --platform linux/arm64,linux/arm/v7,linux/amd64 -t ${{ github.ref_name }} \
             --image-label org.opencontainers.image.title=grafana-operator \
             --image-label org.opencontainers.image.description="An operator for Grafana that installs and manages Grafana instances & Dashboards & Datasources through Kubernetes/OpenShift CRs" \


### PR DESCRIPTION
Enabling this feature makes it possible to download the sbom generate by KO.
I have manually created a release from this PR to trigger this job.

The release job can be found here.
https://github.com/NissesSenap/grafana-operator/actions/runs/6935701889/job/18866382005

```
cosign download sbom --platform linux/amd64 ghcr.io/ghcr.io/nissessenap/grafana-operator/grafana-operator:v5.4.3-sbom3@sha256:cb44133edae1a421f98acc00d82074d03f588f31a805edfb0f203b17af0c6b11
```

